### PR TITLE
Lwt unix client enhancements

### DIFF
--- a/cohttp-lwt-unix/src/client.ml
+++ b/cohttp-lwt-unix/src/client.ml
@@ -1,2 +1,4 @@
 
 include Cohttp_lwt.Make_client(Io)(Net)
+
+let custom_ctx = Net.init

--- a/cohttp-lwt-unix/src/client.mli
+++ b/cohttp-lwt-unix/src/client.mli
@@ -3,3 +3,6 @@
     including the UNIX-specific functions defined in {!C }. *)
 
 include Cohttp_lwt.S.Client with type ctx = Conduit.resolvers
+
+val custom_ctx : ?ctx:Conduit.resolvers -> ?tls_config:Tls.Config.client
+  -> unit -> ctx

--- a/cohttp-lwt-unix/src/client.mli
+++ b/cohttp-lwt-unix/src/client.mli
@@ -4,5 +4,4 @@
 
 include Cohttp_lwt.S.Client with type ctx = Conduit.resolvers
 
-val custom_ctx : ?ctx:Conduit.resolvers -> ?tls_config:Tls.Config.client
-  -> unit -> ctx
+val custom_ctx : ?tls_config:Tls.Config.client -> unit -> ctx

--- a/cohttp-lwt-unix/src/dune
+++ b/cohttp-lwt-unix/src/dune
@@ -4,5 +4,5 @@
  (synopsis "Lwt/Unix backend for Cohttp")
  (preprocess
   (pps ppx_sexp_conv))
- (libraries mirage-crypto-rng.unix fmt logs logs.lwt conduit-lwt
+ (libraries fmt logs logs.lwt conduit-lwt
    conduit-lwt-tls magic-mime lwt.unix cohttp cohttp-lwt))

--- a/cohttp-lwt-unix/src/net.ml
+++ b/cohttp-lwt-unix/src/net.ml
@@ -23,13 +23,15 @@ module IO = Io
 
 type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
+let empty = Conduit_lwt.empty
+
 let authenticator ~host:_ _ = Ok None
 
 let tls_config =
   Tls.Config.client ~authenticator ()
 
-let empty =
-  Conduit_lwt.empty
+let init ?(ctx = empty) ?(tls_config = tls_config) () =
+  ctx
   |> Conduit_lwt.add Conduit_lwt.TCP.protocol
     (Conduit_lwt.TCP.resolve ~port:80)
   |> Conduit_lwt.add ~priority:10 Conduit_lwt_tls.TCP.protocol

--- a/cohttp-lwt-unix/src/net.ml
+++ b/cohttp-lwt-unix/src/net.ml
@@ -23,8 +23,6 @@ module IO = Io
 
 type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
-let () = Mirage_crypto_rng_unix.initialize ()
-
 let authenticator ~host:_ _ = Ok None
 
 let tls_config =

--- a/cohttp-lwt-unix/src/net.ml
+++ b/cohttp-lwt-unix/src/net.ml
@@ -23,32 +23,34 @@ module IO = Io
 
 type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
-let empty = Conduit_lwt.empty
-
 let authenticator ~host:_ _ = Ok None
 
 let tls_config =
   Tls.Config.client ~authenticator ()
 
-let init ?(ctx = empty) ?(tls_config = tls_config) () =
-  ctx
+let init ?(tls_config = tls_config) () =
+  Conduit_lwt.empty
   |> Conduit_lwt.add Conduit_lwt.TCP.protocol
     (Conduit_lwt.TCP.resolve ~port:80)
   |> Conduit_lwt.add ~priority:10 Conduit_lwt_tls.TCP.protocol
     (Conduit_lwt_tls.TCP.resolve ~port:443 ~config:tls_config)
 
+let default_ctx = init ()
+
 let failwith fmt = Format.kasprintf (fun err -> Lwt.fail (Failure err)) fmt
 
-let uri_to_endpoint ?host:(default= "localhost") uri =
-  let v = Uri.host_with_default ~default uri in
+let uri_to_endpoint uri =
+  (match Uri.host uri with
+   | None -> failwith "Invalid uri: no host component in %a" Uri.pp uri
+   | Some h -> Lwt.return h) >>= fun v ->
   let ( >>= ) x f = match x with Ok x -> f x | Error err -> Error err in
   match Domain_name.(of_string v >>= host), Ipaddr.of_string v with
   | Ok domain_name, _ -> Lwt.return (Conduit.Endpoint.domain domain_name)
   | Error _, Ok v -> Lwt.return (Conduit.Endpoint.ip v)
   | Error _, Error _ -> failwith "Invalid uri: %a" Uri.pp uri
 
-let connect_uri ?host ~ctx uri =
-  uri_to_endpoint ?host uri >>= fun edn ->
+let connect_uri ~ctx uri =
+  uri_to_endpoint uri >>= fun edn ->
   Conduit_lwt.resolve ctx edn >>= function
   | Ok flow ->
     let ic, oc = Conduit_lwt.io_of_flow flow in

--- a/cohttp-lwt-unix/src/net.mli
+++ b/cohttp-lwt-unix/src/net.mli
@@ -22,6 +22,8 @@ type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
 val empty : ctx
 
+val init : ?ctx:ctx -> ?tls_config:Tls.Config.client -> unit -> ctx
+
 (** Exceptions from [conduit].
 
     When the [recv] or the [send] {i syscalls} return an error,

--- a/cohttp-lwt-unix/src/net.mli
+++ b/cohttp-lwt-unix/src/net.mli
@@ -20,9 +20,9 @@ module IO = Io
 
 type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
-val empty : ctx
+val default_ctx : ctx
 
-val init : ?ctx:ctx -> ?tls_config:Tls.Config.client -> unit -> ctx
+val init : ?tls_config:Tls.Config.client -> unit -> ctx
 
 (** Exceptions from [conduit].
 
@@ -30,7 +30,6 @@ val init : ?ctx:ctx -> ?tls_config:Tls.Config.client -> unit -> ctx
     [conduit] will reraise it. *)
 
 val connect_uri :
-  ?host:string ->
   ctx:ctx ->
   Uri.t ->
   (Conduit_lwt.flow * Lwt_io.input Lwt_io.channel * Lwt_io.output Lwt_io.channel) Lwt.t

--- a/cohttp-lwt/src/client.ml
+++ b/cohttp-lwt/src/client.ml
@@ -46,7 +46,7 @@ module Make
     | `DELETE -> false
     | _ -> true
 
-  let call ?(ctx= Net.empty) ?headers ?(body=`Empty) ?chunked meth uri =
+  let call ?(ctx = Net.default_ctx) ?headers ?(body=`Empty) ?chunked meth uri =
     let headers = match headers with None -> Header.init () | Some h -> h in
     Net.connect_uri ~ctx uri >>= fun (_conn, ic, oc) ->
     let closefn () = Net.close ic oc in
@@ -93,7 +93,7 @@ module Make
     let body = Body.of_string (Uri.encoded_of_query params) in
     post ?ctx ~chunked:false ~headers ~body uri
 
-  let callv ?(ctx= Net.empty) uri reqs =
+  let callv ?(ctx = Net.default_ctx) uri reqs =
     Net.connect_uri ~ctx uri >>= fun (_conn, ic, oc) ->
     (* Serialise the requests out to the wire *)
     let meth_stream = Lwt_stream.map_s (fun (req,body) ->

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -24,8 +24,8 @@ module type Net = sig
 
   type ctx [@@deriving sexp]
 
-  val empty : ctx
-  val connect_uri : ?host:string -> ctx:ctx -> Uri.t -> (IO.conn * IO.ic * IO.oc) Lwt.t
+  val default_ctx : ctx
+  val connect_uri : ctx:ctx -> Uri.t -> (IO.conn * IO.ic * IO.oc) Lwt.t
   val close_in : IO.ic -> unit
   val close_out : IO.oc -> unit
   val close : IO.ic -> IO.oc -> unit

--- a/cohttp-mirage/src/client.ml
+++ b/cohttp-mirage/src/client.ml
@@ -29,20 +29,22 @@ module Net_IO = struct
 
   type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
-  let empty = Conduit.empty
+  let default_ctx = Conduit.empty
 
   let failwith fmt = Fmt.kstrf (fun err -> Lwt.fail (Failure err)) fmt
 
-  let uri_to_endpoint ?host:(default= "localhost") uri =
-    let v = Uri.host_with_default ~default uri in
+  let uri_to_endpoint uri =
+    (match Uri.host uri with
+     | None -> failwith "Invalid uri: no host component in %a" Uri.pp uri
+     | Some h -> Lwt.return h) >>= fun v ->
     let ( >>= ) x f = match x with Ok x -> f x | Error err -> Error err in
     match Domain_name.(of_string v >>= host), Ipaddr.of_string v with
     | Ok domain_name, _ -> Lwt.return (Conduit.Endpoint.domain domain_name)
     | Error _, Ok v -> Lwt.return (Conduit.Endpoint.ip v)
     | Error _, Error _ -> failwith "Invalid uri: %a" Uri.pp uri
 
-  let connect_uri ?host ~ctx uri =
-    uri_to_endpoint ?host uri >>= fun edn ->
+  let connect_uri ~ctx uri =
+    uri_to_endpoint uri >>= fun edn ->
     Conduit_mirage.resolve ctx edn >>= function
     | Ok flow ->
       let ch = Channel.create flow in


### PR DESCRIPTION
the `Mirage_crypto_rng_lwt.initialize ()` is done in conduit-lwt-tls now (as it should be for potential other users of conduit-lwt-tls).

the second commit re-instantiates the `init ()` function for initializing a ctx - and allows that a custom tls_config is passed.

once mirage/ca-certs is released, we should keep the API, but switch the default tls_config to use the system authenticators.