### PR TITLE
cohttp-lwt-unix: use ca-certs, authenticate client connections

### DIFF
--- a/cohttp-lwt-unix.opam
+++ b/cohttp-lwt-unix.opam
@@ -29,6 +29,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "conduit-lwt" {>= "1.0.3"}
   "conduit-lwt-tls"
+  "ca-certs"
   "cmdliner"
   "magic-mime"
   "logs"

--- a/cohttp-lwt-unix/src/dune
+++ b/cohttp-lwt-unix/src/dune
@@ -5,4 +5,4 @@
  (preprocess
   (pps ppx_sexp_conv))
  (libraries fmt logs logs.lwt conduit-lwt conduit-lwt-tls magic-mime lwt.unix
-   cohttp cohttp-lwt))
+   ca-certs cohttp cohttp-lwt))

--- a/cohttp-lwt-unix/src/net.ml
+++ b/cohttp-lwt-unix/src/net.ml
@@ -23,7 +23,10 @@ module IO = Io
 
 type ctx = (Conduit.resolvers[@sexp.opaque]) [@@deriving sexp]
 
-let authenticator ~host:_ _ = Ok None
+let authenticator =
+  match Ca_certs.authenticator () with
+  | Ok a -> a
+  | Error (`Msg msg) -> failwith msg
 
 let tls_config =
   Tls.Config.client ~authenticator ()


### PR DESCRIPTION
use the new ca-certs library to avoid trust/security regressions